### PR TITLE
Updated to new alias names

### DIFF
--- a/data/data_driven_world/harvest_test_world.json
+++ b/data/data_driven_world/harvest_test_world.json
@@ -5,7 +5,7 @@
    
    "entities" : [
       {
-         "alias" : "stonehearth:large_oak_tree",
+         "alias" : "stonehearth:trees:oak:large",
          
          "position" : {
             "x" : -25,
@@ -14,7 +14,7 @@
       },
       
       {
-         "alias" : "stonehearth:medium_oak_tree",
+         "alias" : "stonehearth:trees:oak:medium",
          
          "position" : {
             "x": -5,
@@ -23,7 +23,7 @@
       },
       
       {
-         "alias" : "stonehearth:small_oak_tree",
+         "alias" : "stonehearth:trees:oak:small",
          
          "position" : {
             "x" : 15,
@@ -32,7 +32,7 @@
       },
       
       {
-         "alias" : "stonehearth:large_juniper_tree",
+         "alias" : "stonehearth:trees:juniper:large",
          
          "position" : {
             "x" : -25,
@@ -41,7 +41,7 @@
       },
       
       {
-         "alias" : "stonehearth:medium_juniper_tree",
+         "alias" : "stonehearth:trees:juniper:medium",
          
          "position" : {
             "x" : -5,
@@ -50,7 +50,7 @@
       },
       
       {
-         "alias" : "stonehearth:small_juniper_tree",
+         "alias" : "stonehearth:trees:juniper:small",
          
          "position" : {
             "x" : 15,
@@ -59,7 +59,7 @@
       },
       
       {
-         "alias" : "stonehearth:large_boulder_1",
+         "alias" : "stonehearth:boulders:large_1",
          
          "position" : {
             "x" : -25,
@@ -68,7 +68,7 @@
       },
       
       {
-         "alias" : "stonehearth:medium_boulder_1",
+         "alias" : "stonehearth:boulders:medium_1",
          
          "position" : {
             "x" : -15,
@@ -77,7 +77,7 @@
       },
       
       {
-         "alias" : "stonehearth:small_boulder",
+         "alias" : "stonehearth:boulders:small",
          
          "position" : {
             "x" : -5,
@@ -86,7 +86,7 @@
       },
       
       {
-         "alias" : "stonehearth:small_boulder",
+         "alias" : "stonehearth:boulders:small",
          
          "position" : {
             "x" : 5,
@@ -97,7 +97,7 @@
       },
       
       {
-         "alias" : "stonehearth:small_boulder",
+         "alias" : "stonehearth:boulders:small",
          
          "position" : {
             "x" : 15,

--- a/data/data_driven_world/mini_game_world.json
+++ b/data/data_driven_world/mini_game_world.json
@@ -37,7 +37,7 @@
       },
       
       {
-         "alias" : "stonehearth:large_oak_tree",
+         "alias" : "stonehearth:trees:oak:large",
          
          "position" : {
             "x": -12,
@@ -46,7 +46,7 @@
       },
       
       {
-         "alias" : "stonehearth:medium_oak_tree",
+         "alias" : "stonehearth:trees:oak:medium",
          
          "position" : {
             "x" : 14,
@@ -55,7 +55,7 @@
       },
       
       {
-         "alias" : "stonehearth:medium_oak_tree",
+         "alias" : "stonehearth:trees:oak:medium",
          
          "position" : {
             "x" : 11,
@@ -64,7 +64,7 @@
       },
       
       {
-         "alias" : "stonehearth:small_oak_tree",
+         "alias" : "stonehearth:trees:oak:small",
          
          "position" : {
             "x" : -10,

--- a/worlds/harvest_test_world.lua
+++ b/worlds/harvest_test_world.lua
@@ -4,23 +4,23 @@ function HarvestTest:start()
    microworld:create_world(64)
 
    -- place some trees around the world
-   microworld:place_entity('stonehearth:large_oak_tree', -25, -25)
-   microworld:place_entity('stonehearth:medium_oak_tree', -5, -25)
-   microworld:place_entity('stonehearth:small_oak_tree',  15, -25)
+   microworld:place_entity('stonehearth:trees:oak:large', -25, -25)
+   microworld:place_entity('stonehearth:trees:oak:medium', -5, -25)
+   microworld:place_entity('stonehearth:trees:oak:small',  15, -25)
 
-   microworld:place_entity('stonehearth:large_juniper_tree', -25, -5)
-   microworld:place_entity('stonehearth:medium_juniper_tree', -5, -5)
-   microworld:place_entity('stonehearth:small_juniper_tree',  15, -5)
+   microworld:place_entity('stonehearth:trees:juniper:large', -25, -5)
+   microworld:place_entity('stonehearth:trees:juniper:medium', -5, -5)
+   microworld:place_entity('stonehearth:trees:juniper:small',  15, -5)
 
    -- place some boulders.  those can be harvested, too!
-   microworld:place_entity('stonehearth:large_boulder_1',  -25, 5)
-   microworld:place_entity('stonehearth:medium_boulder_1', -15, 5)
-   microworld:place_entity('stonehearth:small_boulder',   -5, 5)
+   microworld:place_entity('stonehearth:boulder:large_1',  -25, 5)
+   microworld:place_entity('stonehearth:boulder:medium_1', -15, 5)
+   microworld:place_entity('stonehearth:boulder:small',   -5, 5)
 
-   microworld:place_entity('stonehearth:small_boulder',    5, 5)
+   microworld:place_entity('stonehearth:boulder:small',    5, 5)
        :add_component('mob'):turn_to(90)
 
-   microworld:place_entity('stonehearth:small_boulder',    15, 5)
+   microworld:place_entity('stonehearth:boulder:small',    15, 5)
        :add_component('mob'):turn_to(90)
 
    microworld:place_entity('stonehearth:berry_bush', -25, 15)

--- a/worlds/mini_game_world.lua
+++ b/worlds/mini_game_world.lua
@@ -28,10 +28,10 @@ function MiniGame:start()
    end
 
    -- drop some trees, too
-   microworld:place_entity('stonehearth:large_oak_tree', -12, -12)
-   microworld:place_entity('stonehearth:medium_oak_tree',  14, -13)
-   microworld:place_entity('stonehearth:medium_oak_tree',  11,  16)
-   microworld:place_entity('stonehearth:small_oak_tree', -10,  15)
+   microworld:place_entity('stonehearth:trees:oak:large', -12, -12)
+   microworld:place_entity('stonehearth:trees:oak:medium',  14, -13)
+   microworld:place_entity('stonehearth:trees:oak:medium',  11,  16)
+   microworld:place_entity('stonehearth:trees:oak:small', -10,  15)
 
    -- and a cute little fox.
    microworld:place_entity('stonehearth:red_fox', 2, 2)


### PR DESCRIPTION
The supplied microworlds no longer work due to a refactoring of names some while ago. This should fix them - at the very least, `mini_game` works again.
