### PR TITLE
Add Building_Editor world

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ run the harvest\_test game world every time you run Stonehearth:
 
 Running Building Editor Mod
 ===========================
-Stonehearth.exe" --game.main_mod=microworld --mods.microworld.world=building_editor
+Stonehearth.exe --game.main_mod=microworld --mods.microworld.world=building_editor
 
 
  

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ creates two workers, a stockpile, and some harvestable entities.
 For more information about Stonehearth, please visit http://stonehearth.net
 
 
-
 Installing
 ----------
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ creates two workers, a stockpile, and some harvestable entities.
 
 For more information about Stonehearth, please visit http://stonehearth.net
 
- 
+
 
 Installing
 ----------
@@ -74,6 +74,9 @@ run the harvest\_test game world every time you run Stonehearth:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- 
+Running Building Editor Mod
+===========================
+Stonehearth.exe" --game.main_mod=microworld --mods.microworld.world=building_editor
+
 
  

--- a/data/data_driven_world/building_editor_world.json
+++ b/data/data_driven_world/building_editor_world.json
@@ -1,0 +1,136 @@
+{
+   "world" : {
+      "size" : 64,
+      "town_position" : { "x": 0, "z": 0 }
+   },
+   
+   "entities" : [
+      {
+         "alias" : "stonehearth:decoration:firepit",
+         
+         "position" : {
+            "x" : 0,
+            "z" : 11
+         },
+         
+         "requires_owner": true,
+         "full_size" : true
+      },
+      
+      {
+         "alias" : "stonehearth:plants:berry_bush",
+         
+         "position" : {
+            "x" : 4,
+            "z" : 2
+         },
+         
+         "repeat" : {
+            "x" : 4,
+            "z" : 2
+         },
+         
+         "offset" : {
+            "x" : 4,
+            "z" : 4
+         }
+      },
+      
+      {
+         "alias" : "stonehearth:trees:oak:large",
+         
+         "position" : {
+            "x": -12,
+            "z" : -12
+         }
+      },
+      
+      {
+         "alias" : "stonehearth:trees:oak:medium",
+         
+         "position" : {
+            "x" : 14,
+            "z" : -1
+         }
+      },
+      
+      {
+         "alias" : "stonehearth:trees:oak:medium",
+         
+         "position" : {
+            "x" : 11,
+            "z" : 16
+         }
+      },
+      
+      {
+         "alias" : "stonehearth:trees:oak:small",
+         
+         "position" : {
+            "x" : -10,
+            "z" : 15
+         }
+      },
+      
+      {
+         "alias" : "stonehearth:red_fox",
+         
+         "position" : {
+            "x" : 2,
+            "z" : 2
+         }
+      }
+   ],
+         
+   "citizens": [
+      {
+         "position" : {
+            "x" : -2,
+            "z" : -2
+         }
+      },
+      
+      {
+         "position" : {
+            "x" : -2,
+            "z" : 1
+         },
+         
+         "carrying" : "stonehearth:resources:fiber:silkweed_bundle"
+      },
+      
+      {
+         "position" : {
+            "x" : 1,
+            "z" : -2
+         },
+         
+         "carrying" : "stonehearth:trapper:talisman"
+      },
+      
+      {
+         "position" : {
+            "x" : 1,
+            "z" : 1
+         },
+         
+         "carrying" : "stonehearth:carpenter:talisman"
+      },
+      
+      {
+         "position" : {
+            "x" : 4,
+            "z" : -2
+         }
+      },
+      
+      {
+         "position" : {
+            "x" : 4,
+            "z" : 1
+         },
+         
+         "carrying" : "stonehearth:resources:wood:oak_log"
+      }
+   ]
+}

--- a/data/data_driven_world/building_editor_world.json
+++ b/data/data_driven_world/building_editor_world.json
@@ -1,7 +1,7 @@
 {
    "world" : {
-      "size" : 64,
-      "town_position" : { "x": 0, "z": 0 }
+      "size" : 128,
+      "town_position" : { "x": 100, "z": 10 }
    },
    
    "entities" : [

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
    
    "aliases" : {
       "data_driven:world:mini_game" : "file(data/data_driven_world/mini_game_world.json)",
-	  "data_driven:world:building_editor" : "file(data/data_driven_world/building_editor_world.json)",
+      "data_driven:world:building_editor" : "file(data/data_driven_world/building_editor_world.json)",
       "data_driven:world:harvest_test" : "file(data/data_driven_world/harvest_test_world.json)",
       "data_driven:world:profession_test" : "file(data/data_driven_world/profession_test_world.json)",
       "data_driven:world:equipment_test" : "file(data/data_driven_world/equipment_test_world.json)",

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
    
    "aliases" : {
       "data_driven:world:mini_game" : "file(data/data_driven_world/mini_game_world.json)",
+	  "data_driven:world:building_editor" : "file(data/data_driven_world/building_editor_world.json)",
       "data_driven:world:harvest_test" : "file(data/data_driven_world/harvest_test_world.json)",
       "data_driven:world:profession_test" : "file(data/data_driven_world/profession_test_world.json)",
       "data_driven:world:equipment_test" : "file(data/data_driven_world/equipment_test_world.json)",

--- a/micro_world.lua
+++ b/micro_world.lua
@@ -447,14 +447,12 @@ function MicroWorld:place_all_entities_passing_filter(player_id, x, z, filter_fn
 
    for uri in pairs(all_entities) do
       if filter_fn(uri) then
-         for i = 1, 4 do
-            -- place the entity into the world
-            self:place_item(uri, x, z, player_id)
-            x = (x + 1) % 8
-            if x == 0 then
-               z = z + 1
-            end
-         end
+        -- place the entity into the world
+        self:place_item(uri, x, z, player_id)
+        x = (x + 1) % 12
+        if x == 0 then
+           z = z + 1
+        end
       end
    end
 end
@@ -469,6 +467,22 @@ local alias_is_equipment = function(uri)
    end
 
    return false
+end
+
+local alias_is_furniture = function(uri)
+   local json = radiant.resources.load_json(uri)
+
+   if json['components'] ~= nil and
+      json['components']['stonehearth:entity_forms'] ~= nil then
+      return true
+   end
+
+   return false
+end
+
+--Place all furnitures in all the relevant mods in the test world
+function MicroWorld:place_all_furnitures(player_id, x, z)
+   self:place_all_entities_passing_filter(player_id, x, z, alias_is_furniture)
 end
 
 --Place all the equipment in all the relevant mods in the test world

--- a/worlds/building_editor_world.lua
+++ b/worlds/building_editor_world.lua
@@ -39,6 +39,9 @@ function BuildingEditor:__init()
                                                  level = 6
                                               }
                                           }, 0, 0)
+                                          
+  
+    self:place_all_furnitures(player_id, -30, 10)                                        
 
 end
 

--- a/worlds/building_editor_world.lua
+++ b/worlds/building_editor_world.lua
@@ -1,0 +1,46 @@
+local MicroWorld = require 'micro_world'
+local Point3 = _radiant.csg.Point3
+
+local BuildingEditor = class(MicroWorld)
+
+function BuildingEditor:__init()
+   -- create a tiny world
+   self[MicroWorld]:__init(128)
+   self:create_world()
+
+   local player_id = self:get_session().player_id
+   local pop = stonehearth.population:get_population(player_id)
+
+   -- create a settlement with a banner and firepit
+   -- and 6 workers around the point(0,0)
+   local workers = self:create_settlement({
+                                              carpenter = {
+												 num = 1,
+												 level = 6
+											  },
+											  potter = {
+												 num = 1,
+												 level = 6
+											  },
+											  mason = {
+												 num = 1,
+												 level = 6
+											  },
+											  blacksmith = {
+												 num = 1,
+												 level = 6
+											  },
+											  weaver = {
+												 num = 1,
+												 level = 6
+											  },
+											  engineer = {
+												 num = 1,
+												 level = 6
+											  }
+                                          }, 0, 0)
+
+end
+
+return BuildingEditor
+

--- a/worlds/building_editor_world.lua
+++ b/worlds/building_editor_world.lua
@@ -15,29 +15,29 @@ function BuildingEditor:__init()
    -- and 6 workers around the point(0,0)
    local workers = self:create_settlement({
                                               carpenter = {
-												 num = 1,
-												 level = 6
-											  },
-											  potter = {
-												 num = 1,
-												 level = 6
-											  },
-											  mason = {
-												 num = 1,
-												 level = 6
-											  },
-											  blacksmith = {
-												 num = 1,
-												 level = 6
-											  },
-											  weaver = {
-												 num = 1,
-												 level = 6
-											  },
-											  engineer = {
-												 num = 1,
-												 level = 6
-											  }
+                                                 num = 1,
+                                                 level = 6
+                                              },
+                                              potter = {
+                                                 num = 1,
+                                                 level = 6
+                                              },
+                                              mason = {
+                                                 num = 1,
+                                                 level = 6
+                                              },
+                                              blacksmith = {
+                                                 num = 1,
+                                                 level = 6
+                                              },
+                                              weaver = {
+                                                 num = 1,
+                                                 level = 6
+                                              },
+                                              engineer = {
+                                                 num = 1,
+                                                 level = 6
+                                              }
                                           }, 0, 0)
 
 end


### PR DESCRIPTION
It adds a new microworld that allow player to build custom templates in a flat world with all crafters at max level.
Player can build freely with all the props available in the custom building tool.

Launching it with : 
Stonehearth.exe --game.main_mod=microworld --mods.microworld.world=building_editor